### PR TITLE
Improved Piwik embed code 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+# v1.0.2
+## 13/02/2017
+
+1. [](#improvement)
+    * Changed Piwik embed code, don't include protocol (http or https) in Piwik code (taken from a newer Piwik installation). For compatibility reasons the protocol string will be cut if it is part of the URL. 
+
+
 # v1.0.1
 ## 14/11/2015
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -28,13 +28,14 @@ form:
     siteId:
       type: text
       size: medium
-      label: site ID
+      label: Site ID
       placeholder: 0
       help: piwik tracking ID. In format integer.
      
     sitePiWikURL:
       type: text
-      label: url piwik
+      label: Piwik URL
       size: medium
-      placeholder: http://example.com/privacy-url
-      help: Add url piwik
+      placeholder: example.com/privacy-url
+      description: Please enter Piwik server location without 'http://' or 'https://'
+      help: Add Piwik URL

--- a/piwik.php
+++ b/piwik.php
@@ -27,7 +27,6 @@ class piwikPlugin extends Plugin
         $siteId = trim($this->config->get('plugins.piwik.siteId'));
         $sitePiWikURL = trim($this->config->get('plugins.piwik.sitePiWikURL'));
 
-        // todo: sitepiwikurl without http and https
         $search = array('http://','https://');
         $sitePiWikURL = str_replace($search,'',$sitePiWikURL);
         if ($siteId && $sitePiWikURL) {

--- a/piwik.php
+++ b/piwik.php
@@ -27,22 +27,27 @@ class piwikPlugin extends Plugin
         $siteId = trim($this->config->get('plugins.piwik.siteId'));
         $sitePiWikURL = trim($this->config->get('plugins.piwik.sitePiWikURL'));
 
+        // todo: sitepiwikurl without http and https
+        $search = array('http://','https://');
+        $sitePiWikURL = str_replace($search,'',$sitePiWikURL);
         if ($siteId && $sitePiWikURL) {
             $init = "
 //<!-- Piwik -->
   var _paq = _paq || [];
+  // tracker methods like \"setCustomDimension\" should be called before \"trackPageView\"
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u=\"{$sitePiWikURL}/\";
+    var u=\"//{$sitePiWikURL}/\";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', {$siteId}]);
+    _paq.push(['setSiteId', '{$siteId}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src=\"{$sitePiWikURL}/piwik.php?idsite={$siteId}\" style=\"border:0;\" alt=\"\" /></p></noscript>
-<!-- End Piwik Code -->
+<!-- Piwik Image Tracker-->
+<noscript><img src=\"//{$sitePiWikURL}/piwik.php?idsite={$siteId}&rec=1\" style=\"border:0\" alt=\"\" /></noscript>
+<!-- End Piwik -->
 <script type=\"text/javascript\">
             ";
             $this->grav['assets']->addInlineJs($init);


### PR DESCRIPTION
Hello!

I've taken the JavaScript code from a newer Piwik installation to support both http and https protocols. In Piwik's JavaScript code only the server name is needed, so I've stripped the protocol out of the code. For compatibilty reasons the protocol is cut if it is submitted in the configuration. 

It would be nice if it could be included in the next version. 
Thanks in advance & Kind regards,
   Ralf


